### PR TITLE
Update crafter_proxy.json to use crafter intead of proxied crafter

### DIFF
--- a/src/generated/resources/data/refinedcrafterproxy/recipes/crafter_proxy.json
+++ b/src/generated/resources/data/refinedcrafterproxy/recipes/crafter_proxy.json
@@ -12,7 +12,7 @@
       "item": "refinedstorage:advanced_processor"
     },
     "d": {
-      "item": "refinedcrafterproxy:crafter_proxy"
+      "item": "refinedstorage:crafter"
     }
   },
   "pattern": [


### PR DESCRIPTION
The recipe used the proxied crafter istself, making it unable to craft. I changed it to use the refined storage crafter instead, making it work. I tested it in my local word, and it seems to work. 